### PR TITLE
[STEP 6] Bridge MCP tools with LangChain4j

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      JAVA_HOME: ${{ env.JAVA_HOME_21_X64 }} 
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       GITHUB_OWNER: ${{ secrets.GH_OWNER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,14 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        working-directory: agent
+    env:
+      JAVA_HOME: ${{ env.JAVA_HOME_21_X64 }} 
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      GITHUB_OWNER: ${{ secrets.GH_OWNER }}
+      GITHUB_REPO: ${{ secrets.GH_REPO }}
+      MCP_BASE_URL: http://localhost:8081
+      MCP_PATH: /mcp
 
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +30,7 @@ jobs:
           cache: gradle
 
       - name: Grant execute permission
-        run: chmod +x gradlew
+        run: chmod +x agent/gradlew
 
       - name: Build & Test
-        run: ./gradlew --no-daemon clean test
+        run: agent/gradlew --no-daemon -p agent clean test

--- a/agent/src/main/java/com/example/agent/tools/AgentTool.java
+++ b/agent/src/main/java/com/example/agent/tools/AgentTool.java
@@ -1,0 +1,4 @@
+package com.example.agent.tools;
+
+public interface AgentTool {
+}

--- a/agent/src/main/java/com/example/agent/tools/GitHubMcpTools.java
+++ b/agent/src/main/java/com/example/agent/tools/GitHubMcpTools.java
@@ -1,0 +1,42 @@
+package com.example.agent.tools;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import net.filecode.agent.mcp.McpHttpClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class GitHubMcpTools implements AgentTool {
+
+  private final McpHttpClient mcp;
+  private final String owner;
+  private final String repo;
+
+  public GitHubMcpTools(
+          McpHttpClient mcp,
+          @Value("${github.owner}") String owner,
+          @Value("${github.repo}") String repo
+  ) {
+    this.mcp = mcp;
+    this.owner = owner;
+    this.repo = repo;
+  }
+
+  @Tool("Create a GitHub issue in the configured repository. Use when the user asks to create a task/issue.")
+  public String createIssue(
+          @P("Issue title") String title,
+          @P("Issue body in Markdown") String body
+  ) {
+    Map result = (Map) mcp.callTool("create_issue", Map.of(
+            "owner", owner,
+            "repo", repo,
+            "title", title,
+            "body", body
+    )).block();
+
+    return "Issue created successfully: " + result;
+  }
+}

--- a/agent/src/main/java/com/example/agent/tools/GitHubMcpTools.java
+++ b/agent/src/main/java/com/example/agent/tools/GitHubMcpTools.java
@@ -2,7 +2,7 @@ package com.example.agent.tools;
 
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
-import net.filecode.agent.mcp.McpHttpClient;
+import com.example.agent.mcp.McpHttpClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 


### PR DESCRIPTION
## Context
This PR bridges LangChain4j tool calls to the MCP HTTP client so the agent can execute GitHub actions through MCP.

## What was implemented
- added `AgentTool` marker interface
- added `GitHubMcpTools` Spring component
- exposed `createIssue(...)` as a LangChain4j `@Tool`
- delegated GitHub issue creation to MCP tool `create_issue`
- injected repository context with:
  - `github.owner`
  - `github.repo`